### PR TITLE
Fix pagination / current page tracking

### DIFF
--- a/DSOnboardingFlow.xcodeproj/project.pbxproj
+++ b/DSOnboardingFlow.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = DSOnboardingFlow/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.danstepanov.DSOnboardingFlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -425,6 +426,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = DSOnboardingFlow/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.danstepanov.DSOnboardingFlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -498,6 +500,7 @@
 				5C056F7E1C117E2B00F37509 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		5C056F7F1C117E2B00F37509 /* Build configuration list for PBXNativeTarget "DSOnboardingFlowTests" */ = {
 			isa = XCConfigurationList;
@@ -506,6 +509,7 @@
 				5C056F811C117E2B00F37509 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		5C056F821C117E2B00F37509 /* Build configuration list for PBXNativeTarget "DSOnboardingFlowUITests" */ = {
 			isa = XCConfigurationList;
@@ -514,6 +518,7 @@
 				5C056F841C117E2B00F37509 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/DSOnboardingFlow.xcodeproj/xcuserdata/danstepanov.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/DSOnboardingFlow.xcodeproj/xcuserdata/danstepanov.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -13,6 +13,22 @@
             timestampString = "471210939.328987"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "75"
+            endingLineNumber = "75"
+            landmarkName = "skipButtonTouched(_:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "DSOnboardingFlow/DSPageViewController.swift"
+            timestampString = "471210939.328987"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
             startingLineNumber = "61"
             endingLineNumber = "61"
             landmarkName = "viewDidLoad()"

--- a/DSOnboardingFlow/DSPageViewController.swift
+++ b/DSOnboardingFlow/DSPageViewController.swift
@@ -61,24 +61,20 @@ class DSPageViewController: UIPageViewController, UIPageViewControllerDataSource
         UIApplication.sharedApplication().keyWindow?.bringSubviewToFront(header)
         
         // This is the starting point. Start with step zero.
-//        setViewControllers([firstViewController], direction: .Forward , animated: true, completion: nil)
-        
-        setViewControllers([getStepZero()], direction: .Forward , animated: true, completion: nil)
+        setViewControllers([firstViewController], direction: .Forward , animated: true, completion: nil)
         
         self.view.setNeedsUpdateConstraints()
     }
     
     func skipButtonTouched(sender : AnyObject?) {
         skipButton.alpha = 0
-//        if index == 0 {
-//            index = index + 2
-//            setViewControllers([viewControllerArray.objectAtIndex(index) as! UIViewController], direction: .Forward, animated: true, completion: nil)
-//        } else if index == 1 {
-//            index = index + 1
-//            setViewControllers([viewControllerArray.objectAtIndex(index) as! UIViewController], direction: .Forward, animated: true, completion: nil)
-//        }
-        setViewControllers([getStepTwo()], direction: .Forward, animated: true, completion: nil)
-        
+        if index == 0 {
+            index = index + 2
+            setViewControllers([viewControllerArray.objectAtIndex(index) as! UIViewController], direction: .Forward, animated: true, completion: nil)
+        } else if index == 1 {
+            index = index + 1
+            setViewControllers([viewControllerArray.objectAtIndex(index) as! UIViewController], direction: .Forward, animated: true, completion: nil)
+        }
     }
     
     override func updateViewConstraints() {
@@ -92,17 +88,17 @@ class DSPageViewController: UIPageViewController, UIPageViewControllerDataSource
         // Dispose of any resources that can be recreated.
     }
     
-    func getStepZero() -> DSStepZeroViewController {
-        return DSStepZeroViewController() 
-    }
-    
-    func getStepOne() -> DSStepOneViewController {
-        return DSStepOneViewController()
-    }
-    
-    func getStepTwo() -> DSStepTwoViewController {
-        return DSStepTwoViewController()
-    }
+//    func getStepZero() -> DSStepZeroViewController {
+//        return DSStepZeroViewController() 
+//    }
+//    
+//    func getStepOne() -> DSStepOneViewController {
+//        return DSStepOneViewController()
+//    }
+//    
+//    func getStepTwo() -> DSStepTwoViewController {
+//        return DSStepTwoViewController()
+//    }
     
     func headerConstraints() {
         self.view.addConstraint(NSLayoutConstraint(
@@ -182,76 +178,72 @@ class DSPageViewController: UIPageViewController, UIPageViewControllerDataSource
     
     func pageViewController(pageViewController: UIPageViewController, viewControllerAfterViewController viewController: UIViewController) -> UIViewController? {
 
-//        if index == 0 {
-//            skipButton.alpha = 1
-//            index = index + 1
-//            return viewControllerArray.objectAtIndex(index) as? UIViewController
-//        } else if index == 1 {
-//            skipButton.alpha = 0
-//            index = index + 1
-//            return viewControllerArray.objectAtIndex(index) as? UIViewController
-//        } else {
-//            return nil
-//        }
-
-        if viewController.isKindOfClass(DSStepZeroViewController) {
-            // 0 -> 1
+        if index == 0 {
             skipButton.alpha = 1
-            return getStepOne()
-        } else if viewController.isKindOfClass(DSStepOneViewController) {
-            // 1 -> 2
-            skipButton.alpha = 1
-            return getStepTwo()
-        } else {
+            index = index + 1
+            return viewControllerArray.objectAtIndex(index) as? UIViewController
+        } else if index == 1 {
             skipButton.alpha = 0
-            // 2 -> end of the road
+            index = index + 1
+            return viewControllerArray.objectAtIndex(index) as? UIViewController
+        } else {
             return nil
         }
+
+//        if viewController.isKindOfClass(DSStepZeroViewController) {
+//            // 0 -> 1
+//            skipButton.alpha = 1
+//            return getStepOne()
+//        } else if viewController.isKindOfClass(DSStepOneViewController) {
+//            // 1 -> 2
+//            skipButton.alpha = 1
+//            return getStepTwo()
+//        } else {
+//            skipButton.alpha = 0
+//            // 2 -> end of the road
+//            return nil
+//        }
     }
 
     
     func pageViewController(pageViewController: UIPageViewController, viewControllerBeforeViewController viewController: UIViewController) -> UIViewController? {
         
-//        if index == 2 {
-//            skipButton.alpha = 1
-//            index = index - 1
-//            return viewControllerArray.objectAtIndex(index) as? UIViewController
-//        }
-//        else if index == 1 {
-//            skipButton.alpha = 1
-//            index = index - 1
-//            return viewControllerArray.objectAtIndex(index) as? UIViewController
-//        }
-//        else {
-//            return nil
-//        }
-        if viewController.isKindOfClass(DSStepTwoViewController) {
-            // 2 -> 1
+        if index == 2 {
             skipButton.alpha = 1
-            return getStepOne()
-        } else if viewController.isKindOfClass(DSStepOneViewController) {
-            // 1 -> 0
+            index = index - 1
+            return viewControllerArray.objectAtIndex(index) as? UIViewController
+        } else if index == 1 {
             skipButton.alpha = 1
-            return getStepZero()
+            index = index - 1
+            return viewControllerArray.objectAtIndex(index) as? UIViewController
         } else {
-            skipButton.alpha = 1
-            // 0 -> end of the road
             return nil
         }
+//        if viewController.isKindOfClass(DSStepTwoViewController) {
+//            // 2 -> 1
+//            skipButton.alpha = 1
+//            return getStepOne()
+//        } else if viewController.isKindOfClass(DSStepOneViewController) {
+//            // 1 -> 0
+//            skipButton.alpha = 1
+//            return getStepZero()
+//        } else {
+//            skipButton.alpha = 1
+//            // 0 -> end of the road
+//            return nil
+//        }
         
     }
     
     
     // Enables pagination dots
     func presentationCountForPageViewController(pageViewController: UIPageViewController) -> Int {
-//        return viewControllerArray.count
-        return 3
+        return viewControllerArray.count
     }
     
     // This only gets called once, when setViewControllers is called
     func presentationIndexForPageViewController(pageViewController: UIPageViewController) -> Int {
-//        return index
-            return 0
+        return index
     }
     
 }

--- a/DSOnboardingFlow/DSPageViewController.swift
+++ b/DSOnboardingFlow/DSPageViewController.swift
@@ -73,14 +73,20 @@ class DSPageViewController: UIPageViewController, UIPageViewControllerDataSource
         
         // This is the starting point. Start with step zero.
         setViewControllers([firstViewController], direction: .Forward , animated: true, completion: nil)
+        index = 0 // see `skipButtonTouched` for why this is set here.
         
         self.view.setNeedsUpdateConstraints()
     }
     
     func skipButtonTouched(sender : AnyObject?) {
+        // you could probably get rid of this after moving the code that sets
+        // the alpha to the `didSet` of the index property (see top of class).
         skipButton.alpha = 0
         
         let lastVC = viewControllerArray.lastObject as! UIViewController
+        // we have to set the index ourselves, since we're changing it.
+        // The UIPageViewController delegate methods only get called when the user switches pages.
+        index = viewControllerArray.count - 1
         setViewControllers([lastVC], direction: .Forward, animated: true, completion: nil)
         
 //        if index == 0 {


### PR DESCRIPTION
Track the current pages by using an Integer `tag` of each view controller; whenever a related delegate callback is called, we have the UIPageViewController and can determine the current index from there. Also prints the current index to the console whenever `DSPageViewController().index` changes.

Also, in d84c559, track the current page when we manually change it as well, since the code in this pull request (see 224fd49 specifically) depends on delegate methods, which only get called when the user swipes between view controllers.

At this point, the visibility/alpha for the skip button could be set when the current index is printed to screen (`index`'s `didSet {}`)
